### PR TITLE
ignore images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 node_modules
+.DS_Store
+*.[gG][iI][fF]
+*.[jJ][pP][gG]
+*.[jJ][pP][eE][gG]
+*.[pP][nN][gG]
+*.[tT][iI][fF]
+*.[tT][iI][fF]
+*.[wW][eE][bB][pP]


### PR DESCRIPTION
### case insensitive `.gitignore` rules for ignoring image files

```
*.[gG][iI][fF]
*.[jJ][pP][gG]
*.[jJ][pP][eE][gG]
*.[pP][nN][gG]
*.[tT][iI][fF]
*.[tT][iI][fF]
*.[wW][eE][bB][pP]
```

technique via stack overflow