### PR TITLE
patch sharp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "sharp": "^0.30.1",
+        "sharp": "^0.30.2",
         "wtb": "^0.2.0"
       },
       "bin": {
@@ -1886,13 +1886,13 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "node_modules/sharp": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
-      "integrity": "sha512-ycpz81q8AeVjz1pGvvirQBeJcYE2sXAjcLXR/69LWOe/oxavBLOrenZcTzvTXn83jqAGqY+OuwF+2kFXzbKtDA==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.2.tgz",
+      "integrity": "sha512-mrMeKI5ECTdYhslPlA2TbBtU3nZXMEBcQwI6qYXjPlu1LpW4HBZLFm6xshMI1HpIdEEJ3UcYp5AKifLT/fEHZQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "color": "^4.2.0",
-        "detect-libc": "^2.0.0",
+        "color": "^4.2.1",
+        "detect-libc": "^2.0.1",
         "node-addon-api": "^4.3.0",
         "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",
@@ -3765,12 +3765,12 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "sharp": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
-      "integrity": "sha512-ycpz81q8AeVjz1pGvvirQBeJcYE2sXAjcLXR/69LWOe/oxavBLOrenZcTzvTXn83jqAGqY+OuwF+2kFXzbKtDA==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.2.tgz",
+      "integrity": "sha512-mrMeKI5ECTdYhslPlA2TbBtU3nZXMEBcQwI6qYXjPlu1LpW4HBZLFm6xshMI1HpIdEEJ3UcYp5AKifLT/fEHZQ==",
       "requires": {
-        "color": "^4.2.0",
-        "detect-libc": "^2.0.0",
+        "color": "^4.2.1",
+        "detect-libc": "^2.0.1",
         "node-addon-api": "^4.3.0",
         "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/s9a/dab/issues"
   },
   "dependencies": {
-    "sharp": "^0.30.1",
+    "sharp": "^0.30.2",
     "wtb": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
include [sharp](https://github.com/lovell/sharp) [patch published](https://github.com/lovell/sharp/releases/tag/v0.30.2) today